### PR TITLE
Using jwt if present to grab the test API key from currently logged in user

### DIFF
--- a/source/javascripts/app/_angular.js
+++ b/source/javascripts/app/_angular.js
@@ -1,8 +1,20 @@
 var app = angular.module('scale', ['ngResource']);
 
+function getJWTCookie() {
+  let name = 'jwt';
+  let value = '; ' + document.cookie;
+  let parts = value.split('; ' + name + '=');
+  if (parts.length === 2) return parts.pop().split(';').shift();
+}
+
 app.controller('docsController', ["$scope", "$http", "$resource", function ($scope, $http, $resource) {
   $http.defaults.withCredentials = true;
-  var User = $resource('https://dashboard.scaleapi.com/internal/logged_in_user');
+  var jwt = getJWTCookie();
+  var method = { get: { method: 'GET' } };
+  if (jwt) {
+    method.get.headers = {'authorization': 'JWT ' + jwt};
+  }
+  var User = $resource('https://dashboard.scaleapi.com/internal/logged_in_user', {}, method);
 
   $scope.user = {};
   $scope.ApiKey = 'SCALE_API_KEY';


### PR DESCRIPTION
## Summary of changes
When doing the request to `/internal/logged_in_user` for getting test API key, sending `authorization` header with JWT if it is present.