### PR TITLE
Add skip_human_transcription parameter to audio transcription docs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
     hashie (3.4.4)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.6)
     kramdown (1.12.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -131,4 +131,4 @@ DEPENDENCIES
   rouge (~> 2.0.5)
 
 BUNDLED WITH
-   1.14.3
+   1.15.1

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1301,11 +1301,12 @@ See the <a href="#callbacks">Callback section</a> for more details about callbac
 ```
 
 On your tasks, you will be required to supply a `callback_url`, a fully qualified URL that we will POST with the results of the task when completed. The data will be served as a JSON body (`application/json`). Alternately,
-you can set a default callback URL in your profile, which will be used for tasks that do not specify one.
+you can set a default callback URL in your profile, which will be used for tasks that do not specify one. Additionally, in order to simplify testing and add support for email automation pipelines, you may provide an email address
+as the `callback_url`. In this case, each completed task will result in an email sent with the body as the tasks's JSON payload.
 
 You should respond to the POST request with a 2xx status code. If we do not receive a 2xx status code, we will continue to retry up to 20 times over the course of the next 24 hours.
 
-If we receive a 2xx status code, the task will be populated with a `true` value for the `callback_succeeded` parameter. Otherwise, if we do not recieve a 2xx status code on any retry, the task will be populated with a `false` value for the `callback_succeeded` parameter.
+If we receive a 2xx status code, the task will be populated with a `true` value for the `callback_succeeded` parameter. Otherwise, if we do not receive a 2xx status code on any retry, the task will be populated with a `false` value for the `callback_succeeded` parameter.
 
 ### Getting Started
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1195,6 +1195,7 @@ Parameter | Type | Description
 `phrases` (optional) | [string] | A list of strings containing words and phrases "hints" so that the audio transcription is more likely to recognize them. This can be used to improve the accuracy for specific words and phrases, or to add additional words to the vocabulary for the transcription.
 `urgency` (optional, default `day`) | string | A string describing the urgency of the response. One of `immediate`, `day`, or `week`, where `immediate` is a one-hour response time.
 `metadata` (optional, default `{}`) | object | A set of key/value pairs that you can attach to a task object. It can be useful for storing additional information about the task in a structured format.
+`skip_human_transcription` (optional, default `false`) | boolean | Specifies whether or not to skip human transcription.
 
 ## Callback Format
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1195,7 +1195,7 @@ Parameter | Type | Description
 `phrases` (optional) | [string] | A list of strings containing words and phrases "hints" so that the audio transcription is more likely to recognize them. This can be used to improve the accuracy for specific words and phrases, or to add additional words to the vocabulary for the transcription.
 `urgency` (optional, default `day`) | string | A string describing the urgency of the response. One of `immediate`, `day`, or `week`, where `immediate` is a one-hour response time.
 `metadata` (optional, default `{}`) | object | A set of key/value pairs that you can attach to a task object. It can be useful for storing additional information about the task in a structured format.
-`skip_human_transcription` (optional, default `false`) | boolean | Specifies whether or not to skip human transcription.
+`skip_human_transcription` (optional, default `false`) | boolean | Specifies whether or not to skip human transcription. Skipping human transcription will result in a very fast response and lower price, but will likely have a lower final quality.
 
 ## Callback Format
 


### PR DESCRIPTION
Apparently I included the email callback url doc changes too...