### PR TITLE
adding layers to the image annotation doc

### DIFF
--- a/source/includes/_categorization.mdown
+++ b/source/includes/_categorization.mdown
@@ -111,6 +111,7 @@ Parameter | Type | Description
 `category_ids` (optional) | dictionary | An optional dictionary where the keys are the optional ids, and the values are the category values provided in `categories`.
 `allow_multiple` (optional) | boolean | Default is `false`. Determines whether you allow multiple categories to be chosen for the attachment
 `metadata` (optional, default `{}`) | object | A set of key/value pairs that you can attach to a task object. It can be useful for storing additional information about the task in a structured format.
+`layers` (optional) | object | A set of existing read-only boxes, lines, polygons and/or cuboids to be pre-drawn on the image attachment (this only works if `attachment_type` is `image`). This can be useful e.g. to draw a bounding box indicating which object to categorize within the image. See the <a href="#layers">Layers section</a> in image annotation for more detail.
 
 ## Callback Format
 

--- a/source/includes/_categorization.mdown
+++ b/source/includes/_categorization.mdown
@@ -111,7 +111,7 @@ Parameter | Type | Description
 `category_ids` (optional) | dictionary | An optional dictionary where the keys are the optional ids, and the values are the category values provided in `categories`.
 `allow_multiple` (optional) | boolean | Default is `false`. Determines whether you allow multiple categories to be chosen for the attachment
 `metadata` (optional, default `{}`) | object | A set of key/value pairs that you can attach to a task object. It can be useful for storing additional information about the task in a structured format.
-`layers` (optional) | object | A set of existing read-only boxes, lines, polygons and/or cuboids to be pre-drawn on the image attachment (this only works if `attachment_type` is `image`). This can be useful e.g. to draw a bounding box indicating which object to categorize within the image. See the <a href="#layers">Layers section</a> in image annotation for more detail.
+`layers` (optional) | object | A set of existing read-only boxes, lines, polygons and/or cuboids to be pre-drawn on the image attachment (this only works if `attachment_type` is `image`). This can be useful e.g. to draw a bounding box indicating which object to categorize within the image. See the <a href="#annotation-layers">Layers section</a> in image annotation for more detail.
 
 ## Callback Format
 

--- a/source/includes/_categorization.mdown
+++ b/source/includes/_categorization.mdown
@@ -111,7 +111,7 @@ Parameter | Type | Description
 `category_ids` (optional) | dictionary | An optional dictionary where the keys are the optional ids, and the values are the category values provided in `categories`.
 `allow_multiple` (optional) | boolean | Default is `false`. Determines whether you allow multiple categories to be chosen for the attachment
 `metadata` (optional, default `{}`) | object | A set of key/value pairs that you can attach to a task object. It can be useful for storing additional information about the task in a structured format.
-`layers` (optional) | object | A set of existing read-only boxes, lines, polygons and/or cuboids to be pre-drawn on the image attachment (this only works if `attachment_type` is `image`). This can be useful e.g. to draw a bounding box indicating which object to categorize within the image. See the <a href="#annotation-layers">Layers section</a> in image annotation for more detail.
+`layers` (optional) | object | A set of existing read-only boxes, lines, polygons and/or cuboids to be pre-drawn on the image attachment (this only works if `attachment_type` is `image`). This can be useful e.g. to draw a bounding box indicating which object to categorize within the image. See the <a href="#image-annotation-layers">Layers section</a> in image annotation for more detail.
 
 ## Callback Format
 

--- a/source/includes/_imageannotation.mdown
+++ b/source/includes/_imageannotation.mdown
@@ -2,11 +2,11 @@
 > All of these input formats have the same formatting as our responses, so passing one Scale tasks' data to another Scale task is really easy.
 
 ```js
+// This example uses express with body-parser
 var scaleapi = require('scaleapi');
 
 var client = scaleapi.ScaleClient('{{ApiKey}}');
 
-// This example uses express with body-parser
 app.post('/polygon_task_callback_handler', function(req, res) {
   // Validate callback auth key
   ...
@@ -33,12 +33,14 @@ app.post('/polygon_task_callback_handler', function(req, res) {
 ```
 
 ```python
-from flask import request
+# This example uses Flask
 import scaleapi
+from flask import request, Flask
+
+app = Flask(__name__)
 
 client = scaleapi.ScaleClient('{{ApiKey}}')
 
-# This example uses Flask
 @app.route('/polygon_task_callback_handler', methods=['POST'])
 def create_annotation_task():
   # Validate callback auth key
@@ -63,6 +65,7 @@ def create_annotation_task():
 ```
 
 ```ruby
+# This example uses Rails
 require 'scale'
 
 class ExampleController < ActionController::Base
@@ -70,7 +73,7 @@ class ExampleController < ActionController::Base
     @scale = Scale.new(api_key: '{{ApiKey}}')
   end
 
-  # This example uses Rails, and assumes you map this to a POST route
+  # This should be mapped to a POST route
   def polygon_task_callback_handler
     # Validate callback auth key
     ...

--- a/source/includes/_imageannotation.mdown
+++ b/source/includes/_imageannotation.mdown
@@ -64,29 +64,34 @@ def create_annotation_task():
 
 ```ruby
 require 'scale'
-scale = Scale.new(api_key: '{{ApiKey}}')
 
-# This example uses Rails, and assumes you map this to a POST route
-def create_annotation_task
-  # Validate callback auth key
-  ...
+class ExampleController < ActionController::Base
+  def initialize
+    @scale = Scale.new(api_key: '{{ApiKey}}')
+  end
 
-  polygons = params['response']['annotations']
-  attachment = params['task']['params']['attachment']
+  # This example uses Rails, and assumes you map this to a POST route
+  def polygon_task_callback_handler
+    # Validate callback auth key
+    ...
 
-  task = scale.create_annotation_task({
-    callback_url: 'http://www.example.com/annotation_task_callback_handler',
-    instruction: 'Draw a box around each **car** and **pedestrian**',
-    attachment_type: 'image',
-    attachment: attachment,
-    objects_to_annotate: ['car', 'pedestrian'],
-    with_labels: true,
-    min_width: '30',
-    min_height: '30',
-    layers: {polygons: polygons}
-  })
+    polygons = params['response']['annotations']
+    attachment = params['task']['params']['attachment']
 
-  # do something with the task
+    task = @scale.create_annotation_task({
+      callback_url: 'http://www.example.com/annotation_task_callback_handler',
+      instruction: 'Draw a box around each **car** and **pedestrian**',
+      attachment_type: 'image',
+      attachment: attachment,
+      objects_to_annotate: ['car', 'pedestrian'],
+      with_labels: true,
+      min_width: '30',
+      min_height: '30',
+      layers: {polygons: polygons}
+    })
+
+    # do something with the task
+  end
 end
 ```
 

--- a/source/includes/_imageannotation.mdown
+++ b/source/includes/_imageannotation.mdown
@@ -128,7 +128,7 @@ Parameter | Type | Description
 `instruction` (optional) | string | A markdown-enabled string explaining how to draw the bounding boxes. You can use [markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) to show example images, give structure to your instructions, and more.
 `attachment_type` (optional, default `image`) | string | Describes what type of file the attachment is. We currently only support `image` for the annotation endpoint.
 `metadata` (optional, default `{}`) | object | A set of key/value pairs that you can attach to a task object. It can be useful for storing additional information about the task in a structured format.
-`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#layers">Layers section</a> for more detail.
+`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#annotation-layers">Layers section</a> for more detail.
 
 ### Callback Format
 
@@ -292,7 +292,7 @@ Parameter | Type | Description
 `instruction` (optional) | string | A markdown-enabled string explaining how to draw the points. You can use [markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) to show example images, give structure to your instructions, and more.
 `attachment_type` (optional, default `image`) | string | Describes what type of file the attachment is. We currently only support `image` for the polygon annotation endpoint.
 `metadata` (optional, default `{}`) | object | A set of key/value pairs that you can attach to a task object. It can be useful for storing additional information about the task in a structured format.
-`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#layers">Layers section</a> for more detail.
+`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#annotation-layers">Layers section</a> for more detail.
 
 ### Callback Format
 
@@ -460,7 +460,7 @@ Parameter | Type | Description
 `min_vertices` (optional, default 1) | number | An optional parameter defining the minimum number of vertices in a valid line annotation for your request.
 `max_vertices` (optional, default `null`) | number | An optional parameter defining the maximum number of vertices in a valid line annotation for your request. Must be at least `min_vertices`.
 `metadata` (optional, default `{}`) | object | A set of key/value pairs that you can attach to a task object. It can be useful for storing additional information about the task in a structured format.
-`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#layers">Layers section</a> for more detail.
+`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#annotation-layers">Layers section</a> for more detail.
 
 ### Callback Format
 
@@ -630,7 +630,7 @@ Parameter | Type | Description
 `min_vertices` (optional, default 1) | number | An optional parameter defining the minimum number of vertices in a valid polygon annotation for your request.
 `max_vertices` (optional, default `null`) | number | An optional parameter defining the maximum number of vertices in a valid polygon annotation for your request. Must be at least `min_vertices`.
 `metadata` (optional, default `{}`) | object | A set of key/value pairs that you can attach to a task object. It can be useful for storing additional information about the task in a structured format.
-`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#layers">Layers section</a> for more detail.
+`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#annotation-layers">Layers section</a> for more detail.
 
 ### Callback Format
 
@@ -879,30 +879,77 @@ The `response` field, which is part of the callback POST request and permanently
 See the <a href="#callbacks">Callback section</a> for more details about callbacks.
 </aside>
 
-## Layers
-> Example layers param with all layer types in use
+# Annotation Layers
+> All of these input formats have the same formatting as our responses, so passing one Scale tasks' data to another Scale task is really easy.
+
+```js
+app.post('/polygon_task_callback_handler', function(req, res) {
+  var polygons = req.body.response.annotations;
+
+  var scaleapi = require('scaleapi');
+
+  var client = scaleapi.ScaleClient('{{ApiKey}}')
+
+  client.createAnnotationTask({
+    'callback_url': 'http://www.example.com/callback',
+    'instruction': 'Draw a box around each **car** and **pedestrian**',
+    'attachment_type': 'image',
+    'attachment': 'http://i.imgur.com/XOJbalC.jpg',
+    'objects_to_annotate': ['car', 'pedestrian'],
+    'with_labels': true,
+    'min_width': '30',
+    'min_height': '30',
+    'layers': {
+      'polygons': polygons
+    }
+  }, (err, task) => {
+      // do something with task
+  });
+});
+```
+
+“Layers” can be used to specify existing (read-only) boxes, lines, polygons, and/or cuboids to be pre-drawn on an image.
+
+For instance, you could specify boxes around the cars of an image, for a task that requires drawing polygons around the currently boxed cars. Or you could create a task for drawing boxes around all cars which you hadn't already recognized.
+
+To specify layers, you can pass an optional `layers` parameter in the request for `annotation`, `lineannotation`, `polygonannotation`, or `pointannotation` tasks. They can also be used in `categorization` tasks if the `attachment_type` is `image`.
+
+The `layers` parameter can contains fields for `boxes`, `lines`, `polygons`, and `cuboids`, which are arrays of the corresponding elements. Each of these elements are specified in the same format as the responses for their respective endpoints.
+
+## Boxes
+> Example layers param with boxes
 
 ```json
 {
     "lines": [
+        ...
+    ],
+    "polygons": [
+        ...
+    ],
+    "boxes": [
         {
-            "vertices": [
-                {
-                    "y": 323,
-                    "x": 414
-                },
-                {
-                    "y": 164,
-                    "x": 616
-                },
-                {
-                    "y": 334,
-                    "x": 776
-                }
-            ],
-            "label" : "crosswalk"
+            "label": "car",
+            "height": 97,
+            "width": 147,
+            "top": 229,
+            "left": 300
         }
     ],
+    "cuboids": [
+        ...
+    ]
+}
+```
+
+Each of the `boxes` is specified with an object containing `left`, `top`, `width`, and `height` keys, and an optional `label`.
+
+## Polygons
+> Example layers param with polygons
+
+```json
+{
+    ...
     "polygons": [
         {
             "vertices": [
@@ -921,16 +968,58 @@ See the <a href="#callbacks">Callback section</a> for more details about callbac
             ],
             "label": "building"
         }
-    ],
-    "boxes": [
+    ]
+}
+```
+
+`polygons` are objects with an optional `label` field, and a `vertices` field which contains a list of objects with `x` and `y` attributes.
+
+## Lines
+> Example layers param with lines
+
+```json
+{
+    ...
+    "lines": [
         {
-            "label": "car",
-            "height": 97,
-            "width": 147,
-            "top": 229,
-            "left": 300
+            "vertices": [
+                {
+                    "y": 323,
+                    "x": 414
+                },
+                {
+                    "y": 164,
+                    "x": 616
+                },
+                {
+                    "y": 334,
+                    "x": 776
+                }
+            ],
+            "label" : "crosswalk",
+            "spline": true
         }
-    ],
+    ]
+}
+```
+
+`lines` are objects with an optional `label` field, and a `vertices` field which contains a list of objects with `x` and `y` attributes, similar to polygons. Additionally, line objects have an optional `spline` flag, which determines whether the curve used is linear (if the value is `false` or the param is not passed) or cardinal (if the value is `true`).
+
+## Cuboids
+`cuboids` are described in a similar way as polygons or lines, but the `vertices` also need a `description`, using the following values to identify them:
+
+- face-topleft
+- face-bottomleft
+- face-topright
+- face-bottomright
+- side-topcorner
+- side-bottomcorner
+
+> Example layers param with cuboids
+
+```json
+{
+    ...
     "cuboids": [
         {
             "vertices" : [
@@ -970,29 +1059,3 @@ See the <a href="#callbacks">Callback section</a> for more details about callbac
     ]
 }
 ```
-
-“Layers” can be used to specify existing (read-only) boxes, lines, polygons, and/or cuboids to be pre-drawn on an image. For instance, you could specify boxes around the cars of an image, for a task that requires drawing polygons around the currently boxed cars.
-
-To specify layers, you can pass an optional `layers` parameter in the request for `annotation`, `lineannotation`, `polygonannotation`, or `pointannotation` tasks.
-
-The `layers` parameter can contains fields for `boxes`, `lines`, `polygons`, and `cuboids`, which are arrays of the corresponding elements. Each of these elements are specified as in the responses for their respective endpoints, namely:
-
-### Boxes
-Each of the `boxes` is specified with an object containing `left`, `top`, `width`, and `height` keys, and an optional `label`.
-
-### Polygons
-`polygons` are objects with an optional `label` field, and a `vertices` field which contains a list of objects with `x` and `y` attributes.
-
-### Lines
-`lines` are objects with an optional `label` field, and a `vertices` field which contains a list of objects with `x` and `y` attributes, similar to polygons. Additionally, line objects have an optional `spline` flag, which determines whether the curve used is linear (if the value is `false` or the param is not passed) or cardinal (if the value is `true`).
-
-
-### Cuboids
-`cuboids` are described in a similar way as polygons or lines, but the `vertices` also need a `description`, using the following values to identify them:
-
-- face-topleft
-- face-bottomleft
-- face-topright
-- face-bottomright
-- side-topcorner
-- side-bottomcorner

--- a/source/includes/_imageannotation.mdown
+++ b/source/includes/_imageannotation.mdown
@@ -1,3 +1,239 @@
+# Image Annotation Layers
+> All of these input formats have the same formatting as our responses, so passing one Scale tasks' data to another Scale task is really easy.
+
+```js
+app.post('/polygon_task_callback_handler', function(req, res) {
+  // Validate callback auth key
+  ...
+
+  var polygons = req.body.response.annotations;
+
+  var scaleapi = require('scaleapi');
+
+  var client = scaleapi.ScaleClient('{{ApiKey}}')
+
+  client.createAnnotationTask({
+    'callback_url': 'http://www.example.com/callback',
+    'instruction': 'Draw a box around each **car** and **pedestrian**',
+    'attachment_type': 'image',
+    'attachment': 'http://i.imgur.com/XOJbalC.jpg',
+    'objects_to_annotate': ['car', 'pedestrian'],
+    'with_labels': true,
+    'min_width': '30',
+    'min_height': '30',
+    'layers': {
+      'polygons': polygons
+    }
+  }, (err, task) => {
+      // do something with task
+  });
+});
+```
+
+```python
+from flask import request
+import scaleapi
+
+client = scaleapi.ScaleClient('{{ApiKey}}')
+
+@app.route('/polygon_task_callback_handler', methods=['POST'])
+def create_annotation_task():
+  # Validate callback auth key
+  ...
+
+  task = client.create_annotation_task(
+      callback_url='http://www.example.com/callback',
+      instruction='Draw a box around each **car** and **pedestrian**',
+      attachment_type='image',
+      attachment='http://i.imgur.com/XOJbalC.jpg',
+      objects_to_annotate=['car', 'pedestrian'],
+      with_labels=True,
+      min_width='30',
+      min_height='30',
+      layers={'polygons': request.json['response']['annotations']}
+  )
+
+  # do something with the task
+```
+
+```ruby
+require 'scale'
+scale = Scale.new(api_key: '{{ApiKey}}')
+
+# This should be mapped to a POST route
+def create_annotation_task
+  # Validate callback auth key
+  ...
+
+  task = scale.create_annotation_task({
+    callback_url: 'http://www.example.com/callback',
+    instruction: 'Draw a box around each **car** and **pedestrian**',
+    attachment_type: 'image',
+    attachment: 'http://i.imgur.com/XOJbalC.jpg',
+    objects_to_annotate: ['car', 'pedestrian'],
+    with_labels: true,
+    min_width: '30',
+    min_height: '30',
+    layers: {polygons: params['response']['annotations']}
+  })
+
+  # do something with the task
+end
+```
+
+“Layers” can be used to specify existing (read-only) boxes, lines, polygons, and/or cuboids to be pre-drawn on an image.
+
+For instance, you could specify boxes around the cars of an image, for a task that requires drawing polygons around the currently boxed cars. Or you could create a task for drawing boxes around all cars which you hadn't already recognized.
+
+To specify layers, you can pass an optional `layers` parameter in the request for `annotation`, `lineannotation`, `polygonannotation`, or `pointannotation` tasks. They can also be used in `categorization` tasks if the `attachment_type` is `image`.
+
+The `layers` parameter can contains fields for `boxes`, `lines`, `polygons`, and `cuboids`, which are arrays of the corresponding elements. Each of these elements are specified in the same format as the responses for their respective endpoints.
+
+## Boxes
+> Example layers param with boxes
+
+```json
+{
+    "lines": [
+        ...
+    ],
+    "polygons": [
+        ...
+    ],
+    "boxes": [
+        {
+            "label": "car",
+            "height": 97,
+            "width": 147,
+            "top": 229,
+            "left": 300
+        }
+    ],
+    "cuboids": [
+        ...
+    ]
+}
+```
+
+Each of the `boxes` is specified with an object containing `left`, `top`, `width`, and `height` keys, and an optional `label`.
+
+## Polygons
+> Example layers param with polygons
+
+```json
+{
+    ...
+    "polygons": [
+        {
+            "vertices": [
+                {
+                    "y": 145,
+                    "x": 356
+                },
+                {
+                    "y": 103,
+                    "x": 502
+                },
+                {
+                    "y": 264,
+                    "x": 482
+                }
+            ],
+            "label": "building"
+        }
+    ]
+}
+```
+
+`polygons` are objects with an optional `label` field, and a `vertices` field which contains a list of objects with `x` and `y` attributes.
+
+## Lines
+> Example layers param with lines
+
+```json
+{
+    ...
+    "lines": [
+        {
+            "vertices": [
+                {
+                    "y": 323,
+                    "x": 414
+                },
+                {
+                    "y": 164,
+                    "x": 616
+                },
+                {
+                    "y": 334,
+                    "x": 776
+                }
+            ],
+            "label" : "crosswalk",
+            "spline": true
+        }
+    ]
+}
+```
+
+`lines` are objects with an optional `label` field, and a `vertices` field which contains a list of objects with `x` and `y` attributes, similar to polygons. Additionally, line objects have an optional `spline` flag, which determines whether the curve used is linear (if the value is `false` or the param is not passed) or cardinal (if the value is `true`).
+
+## Cuboids
+
+> Example layers param with cuboids
+
+```json
+{
+    ...
+    "cuboids": [
+        {
+            "vertices" : [
+                {
+                    "description" : "face-topleft",
+                    "y" : 219.0,
+                    "x" : 137.0
+                },
+                {
+                    "description" : "face-bottomleft",
+                    "y" : 318.0,
+                    "x" : 137.0
+                },
+                {
+                    "description" : "face-topright",
+                    "y" : 219.0,
+                    "x" : 245.0
+                },
+                {
+                    "description" : "face-bottomright",
+                    "y" : 318.0,
+                    "x" : 245.0
+                },
+                {
+                    "description" : "side-topcorner",
+                    "y" : 165.0,
+                    "x" : 316.0
+                },
+                {
+                    "description" : "side-bottomcorner",
+                    "y" : 264.0,
+                    "x" : 316.0
+                }
+            ],
+            "label" : "car"
+        }
+    ]
+}
+```
+
+`cuboids` are described in a similar way as polygons or lines, but the `vertices` also need a `description`, using the following values to identify them:
+
+- face-topleft
+- face-bottomleft
+- face-topright
+- face-bottomright
+- side-topcorner
+- side-bottomcorner
+
 # Create Image Annotation Tasks
 
 ## Bounding Box Annotation
@@ -128,7 +364,7 @@ Parameter | Type | Description
 `instruction` (optional) | string | A markdown-enabled string explaining how to draw the bounding boxes. You can use [markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) to show example images, give structure to your instructions, and more.
 `attachment_type` (optional, default `image`) | string | Describes what type of file the attachment is. We currently only support `image` for the annotation endpoint.
 `metadata` (optional, default `{}`) | object | A set of key/value pairs that you can attach to a task object. It can be useful for storing additional information about the task in a structured format.
-`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#annotation-layers">Layers section</a> for more detail.
+`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#image-annotation-layers">Layers section</a> for more detail.
 
 ### Callback Format
 
@@ -292,7 +528,7 @@ Parameter | Type | Description
 `instruction` (optional) | string | A markdown-enabled string explaining how to draw the points. You can use [markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) to show example images, give structure to your instructions, and more.
 `attachment_type` (optional, default `image`) | string | Describes what type of file the attachment is. We currently only support `image` for the polygon annotation endpoint.
 `metadata` (optional, default `{}`) | object | A set of key/value pairs that you can attach to a task object. It can be useful for storing additional information about the task in a structured format.
-`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#annotation-layers">Layers section</a> for more detail.
+`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#image-annotation-layers">Layers section</a> for more detail.
 
 ### Callback Format
 
@@ -460,7 +696,7 @@ Parameter | Type | Description
 `min_vertices` (optional, default 1) | number | An optional parameter defining the minimum number of vertices in a valid line annotation for your request.
 `max_vertices` (optional, default `null`) | number | An optional parameter defining the maximum number of vertices in a valid line annotation for your request. Must be at least `min_vertices`.
 `metadata` (optional, default `{}`) | object | A set of key/value pairs that you can attach to a task object. It can be useful for storing additional information about the task in a structured format.
-`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#annotation-layers">Layers section</a> for more detail.
+`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#image-annotation-layers">Layers section</a> for more detail.
 
 ### Callback Format
 
@@ -630,7 +866,7 @@ Parameter | Type | Description
 `min_vertices` (optional, default 1) | number | An optional parameter defining the minimum number of vertices in a valid polygon annotation for your request.
 `max_vertices` (optional, default `null`) | number | An optional parameter defining the maximum number of vertices in a valid polygon annotation for your request. Must be at least `min_vertices`.
 `metadata` (optional, default `{}`) | object | A set of key/value pairs that you can attach to a task object. It can be useful for storing additional information about the task in a structured format.
-`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#annotation-layers">Layers section</a> for more detail.
+`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#image-annotation-layers">Layers section</a> for more detail.
 
 ### Callback Format
 
@@ -878,238 +1114,3 @@ The `response` field, which is part of the callback POST request and permanently
 <aside class="notice">
 See the <a href="#callbacks">Callback section</a> for more details about callbacks.
 </aside>
-
-# Annotation Layers
-> All of these input formats have the same formatting as our responses, so passing one Scale tasks' data to another Scale task is really easy.
-
-```js
-app.post('/polygon_task_callback_handler', function(req, res) {
-  // Validate callback auth key
-  ...
-
-  var polygons = req.body.response.annotations;
-
-  var scaleapi = require('scaleapi');
-
-  var client = scaleapi.ScaleClient('{{ApiKey}}')
-
-  client.createAnnotationTask({
-    'callback_url': 'http://www.example.com/callback',
-    'instruction': 'Draw a box around each **car** and **pedestrian**',
-    'attachment_type': 'image',
-    'attachment': 'http://i.imgur.com/XOJbalC.jpg',
-    'objects_to_annotate': ['car', 'pedestrian'],
-    'with_labels': true,
-    'min_width': '30',
-    'min_height': '30',
-    'layers': {
-      'polygons': polygons
-    }
-  }, (err, task) => {
-      // do something with task
-  });
-});
-```
-
-```python
-from flask import request
-import scaleapi
-
-client = scaleapi.ScaleClient('{{ApiKey}}')
-
-@app.route('/polygon_task_callback_handler', methods=['POST'])
-def create_annotation_task():
-  # Validate callback auth key
-  ...
-
-  task = client.create_annotation_task(
-      callback_url='http://www.example.com/callback',
-      instruction='Draw a box around each **car** and **pedestrian**',
-      attachment_type='image',
-      attachment='http://i.imgur.com/XOJbalC.jpg',
-      objects_to_annotate=['car', 'pedestrian'],
-      with_labels=True,
-      min_width='30',
-      min_height='30',
-      layers={'polygons': request.json['response']['annotations']}
-  )
-
-  # do something with the task
-```
-
-```ruby
-require 'scale'
-scale = Scale.new(api_key: '{{ApiKey}}')
-
-# This should be mapped to a POST route
-def create_annotation_task
-  # Validate callback auth key
-  ...
-
-  task = scale.create_annotation_task({
-    callback_url: 'http://www.example.com/callback',
-    instruction: 'Draw a box around each **car** and **pedestrian**',
-    attachment_type: 'image',
-    attachment: 'http://i.imgur.com/XOJbalC.jpg',
-    objects_to_annotate: ['car', 'pedestrian'],
-    with_labels: true,
-    min_width: '30',
-    min_height: '30',
-    layers: {polygons: params['response']['annotations']}
-  })
-
-  # do something with the task
-end
-```
-
-“Layers” can be used to specify existing (read-only) boxes, lines, polygons, and/or cuboids to be pre-drawn on an image.
-
-For instance, you could specify boxes around the cars of an image, for a task that requires drawing polygons around the currently boxed cars. Or you could create a task for drawing boxes around all cars which you hadn't already recognized.
-
-To specify layers, you can pass an optional `layers` parameter in the request for `annotation`, `lineannotation`, `polygonannotation`, or `pointannotation` tasks. They can also be used in `categorization` tasks if the `attachment_type` is `image`.
-
-The `layers` parameter can contains fields for `boxes`, `lines`, `polygons`, and `cuboids`, which are arrays of the corresponding elements. Each of these elements are specified in the same format as the responses for their respective endpoints.
-
-## Boxes
-> Example layers param with boxes
-
-```json
-{
-    "lines": [
-        ...
-    ],
-    "polygons": [
-        ...
-    ],
-    "boxes": [
-        {
-            "label": "car",
-            "height": 97,
-            "width": 147,
-            "top": 229,
-            "left": 300
-        }
-    ],
-    "cuboids": [
-        ...
-    ]
-}
-```
-
-Each of the `boxes` is specified with an object containing `left`, `top`, `width`, and `height` keys, and an optional `label`.
-
-## Polygons
-> Example layers param with polygons
-
-```json
-{
-    ...
-    "polygons": [
-        {
-            "vertices": [
-                {
-                    "y": 145,
-                    "x": 356
-                },
-                {
-                    "y": 103,
-                    "x": 502
-                },
-                {
-                    "y": 264,
-                    "x": 482
-                }
-            ],
-            "label": "building"
-        }
-    ]
-}
-```
-
-`polygons` are objects with an optional `label` field, and a `vertices` field which contains a list of objects with `x` and `y` attributes.
-
-## Lines
-> Example layers param with lines
-
-```json
-{
-    ...
-    "lines": [
-        {
-            "vertices": [
-                {
-                    "y": 323,
-                    "x": 414
-                },
-                {
-                    "y": 164,
-                    "x": 616
-                },
-                {
-                    "y": 334,
-                    "x": 776
-                }
-            ],
-            "label" : "crosswalk",
-            "spline": true
-        }
-    ]
-}
-```
-
-`lines` are objects with an optional `label` field, and a `vertices` field which contains a list of objects with `x` and `y` attributes, similar to polygons. Additionally, line objects have an optional `spline` flag, which determines whether the curve used is linear (if the value is `false` or the param is not passed) or cardinal (if the value is `true`).
-
-## Cuboids
-`cuboids` are described in a similar way as polygons or lines, but the `vertices` also need a `description`, using the following values to identify them:
-
-- face-topleft
-- face-bottomleft
-- face-topright
-- face-bottomright
-- side-topcorner
-- side-bottomcorner
-
-> Example layers param with cuboids
-
-```json
-{
-    ...
-    "cuboids": [
-        {
-            "vertices" : [
-                {
-                    "description" : "face-topleft",
-                    "y" : 219.0,
-                    "x" : 137.0
-                },
-                {
-                    "description" : "face-bottomleft",
-                    "y" : 318.0,
-                    "x" : 137.0
-                },
-                {
-                    "description" : "face-topright",
-                    "y" : 219.0,
-                    "x" : 245.0
-                },
-                {
-                    "description" : "face-bottomright",
-                    "y" : 318.0,
-                    "x" : 245.0
-                },
-                {
-                    "description" : "side-topcorner",
-                    "y" : 165.0,
-                    "x" : 316.0
-                },
-                {
-                    "description" : "side-bottomcorner",
-                    "y" : 264.0,
-                    "x" : 316.0
-                }
-            ],
-            "label" : "car"
-        }
-    ]
-}
-```

--- a/source/includes/_imageannotation.mdown
+++ b/source/includes/_imageannotation.mdown
@@ -874,3 +874,121 @@ The `response` field, which is part of the callback POST request and permanently
 <aside class="notice">
 See the <a href="#callbacks">Callback section</a> for more details about callbacks.
 </aside>
+
+## Layers
+> Example layers param with all layer types in use
+
+```json
+{
+    "lines": [
+        {
+            "vertices": [
+                {
+                    "y": 323,
+                    "x": 414
+                },
+                {
+                    "y": 164,
+                    "x": 616
+                },
+                {
+                    "y": 334,
+                    "x": 776
+                }
+            ],
+            "label" : "crosswalk"
+        }
+    ],
+    "polygons": [
+        {
+            "vertices": [
+                {
+                    "y": 145,
+                    "x": 356
+                },
+                {
+                    "y": 103,
+                    "x": 502
+                },
+                {
+                    "y": 264,
+                    "x": 482
+                }
+            ],
+            "label": "building"
+        }
+    ],
+    "boxes": [
+        {
+            "label": "car",
+            "height": 97,
+            "width": 147,
+            "top": 229,
+            "left": 300
+        }
+    ],
+    "cuboids": [
+        {
+            "vertices" : [
+                {
+                    "description" : "face-topleft",
+                    "y" : 219.0,
+                    "x" : 137.0
+                },
+                {
+                    "description" : "face-bottomleft",
+                    "y" : 318.0,
+                    "x" : 137.0
+                },
+                {
+                    "description" : "face-topright",
+                    "y" : 219.0,
+                    "x" : 245.0
+                },
+                {
+                    "description" : "face-bottomright",
+                    "y" : 318.0,
+                    "x" : 245.0
+                },
+                {
+                    "description" : "side-topcorner",
+                    "y" : 165.0,
+                    "x" : 316.0
+                },
+                {
+                    "description" : "side-bottomcorner",
+                    "y" : 264.0,
+                    "x" : 316.0
+                }
+            ],
+            "label" : "car"
+        }
+    ]
+}
+```
+
+“Layers” can be used to specify existing (read-only) boxes, lines, polygons, and/or cuboids to be pre-drawn on an image. For instance, you could specify boxes around the cars of an image, for a task that requires drawing polygons around the currently boxed cars.
+
+To specify layers, you can pass an optional `layers` parameter in the request for `annotation`, `lineannotation`, `polygonannotation`, or `pointannotation` tasks.
+
+The `layers` parameter can contains fields for `boxes`, `lines`, `polygons`, and `cuboids`, which are arrays of the corresponding elements. Each of these elements are specified as in the responses for their respective endpoints, namely:
+
+### Boxes
+Each of the `boxes` is specified with an object containing `left`, `top`, `width`, and `height` keys, and an optional `label`.
+
+### Polygons
+`polygons` are objects with an optional `label` field, and a `vertices` field which contains a list of objects with `x` and `y` attributes.
+
+### Lines
+`lines` are objects with an optional `label` field, and a `vertices` field which contains a list of objects with `x` and `y` attributes, similar to polygons. Additionally, line objects have an optional `spline` flag, which determines whether the curve used is linear (if the value is `false` or the param is not passed) or cardinal (if the value is `true`).
+
+
+### Cuboids
+`cuboids` are described in a similar way as polygons or lines, but the `vertices` also need a `description`, using the following values to identify them:
+
+- face-topleft
+- face-bottomleft
+- face-topright
+- face-bottomright
+- side-topcorner
+- side-bottomcorner

--- a/source/includes/_imageannotation.mdown
+++ b/source/includes/_imageannotation.mdown
@@ -128,6 +128,7 @@ Parameter | Type | Description
 `instruction` (optional) | string | A markdown-enabled string explaining how to draw the bounding boxes. You can use [markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) to show example images, give structure to your instructions, and more.
 `attachment_type` (optional, default `image`) | string | Describes what type of file the attachment is. We currently only support `image` for the annotation endpoint.
 `metadata` (optional, default `{}`) | object | A set of key/value pairs that you can attach to a task object. It can be useful for storing additional information about the task in a structured format.
+`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#layers">Layers section</a> for more detail.
 
 ### Callback Format
 
@@ -291,6 +292,7 @@ Parameter | Type | Description
 `instruction` (optional) | string | A markdown-enabled string explaining how to draw the points. You can use [markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) to show example images, give structure to your instructions, and more.
 `attachment_type` (optional, default `image`) | string | Describes what type of file the attachment is. We currently only support `image` for the polygon annotation endpoint.
 `metadata` (optional, default `{}`) | object | A set of key/value pairs that you can attach to a task object. It can be useful for storing additional information about the task in a structured format.
+`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#layers">Layers section</a> for more detail.
 
 ### Callback Format
 
@@ -458,6 +460,7 @@ Parameter | Type | Description
 `min_vertices` (optional, default 1) | number | An optional parameter defining the minimum number of vertices in a valid line annotation for your request.
 `max_vertices` (optional, default `null`) | number | An optional parameter defining the maximum number of vertices in a valid line annotation for your request. Must be at least `min_vertices`.
 `metadata` (optional, default `{}`) | object | A set of key/value pairs that you can attach to a task object. It can be useful for storing additional information about the task in a structured format.
+`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#layers">Layers section</a> for more detail.
 
 ### Callback Format
 
@@ -627,6 +630,7 @@ Parameter | Type | Description
 `min_vertices` (optional, default 1) | number | An optional parameter defining the minimum number of vertices in a valid polygon annotation for your request.
 `max_vertices` (optional, default `null`) | number | An optional parameter defining the maximum number of vertices in a valid polygon annotation for your request. Must be at least `min_vertices`.
 `metadata` (optional, default `{}`) | object | A set of key/value pairs that you can attach to a task object. It can be useful for storing additional information about the task in a structured format.
+`layers` (optional) | object | A set of existing read-only objects to be pre-drawn on the image. See the <a href="#layers">Layers section</a> for more detail.
 
 ### Callback Format
 

--- a/source/includes/_imageannotation.mdown
+++ b/source/includes/_imageannotation.mdown
@@ -884,6 +884,9 @@ See the <a href="#callbacks">Callback section</a> for more details about callbac
 
 ```js
 app.post('/polygon_task_callback_handler', function(req, res) {
+  // Validate callback auth key
+  ...
+
   var polygons = req.body.response.annotations;
 
   var scaleapi = require('scaleapi');
@@ -906,6 +909,57 @@ app.post('/polygon_task_callback_handler', function(req, res) {
       // do something with task
   });
 });
+```
+
+```python
+from flask import request
+import scaleapi
+
+client = scaleapi.ScaleClient('{{ApiKey}}')
+
+@app.route('/polygon_task_callback_handler', methods=['POST'])
+def create_annotation_task():
+  # Validate callback auth key
+  ...
+
+  task = client.create_annotation_task(
+      callback_url='http://www.example.com/callback',
+      instruction='Draw a box around each **car** and **pedestrian**',
+      attachment_type='image',
+      attachment='http://i.imgur.com/XOJbalC.jpg',
+      objects_to_annotate=['car', 'pedestrian'],
+      with_labels=True,
+      min_width='30',
+      min_height='30',
+      layers={'polygons': request.json['response']['annotations']}
+  )
+
+  # do something with the task
+```
+
+```ruby
+require 'scale'
+scale = Scale.new(api_key: '{{ApiKey}}')
+
+# This should be mapped to a POST route
+def create_annotation_task
+  # Validate callback auth key
+  ...
+
+  task = scale.create_annotation_task({
+    callback_url: 'http://www.example.com/callback',
+    instruction: 'Draw a box around each **car** and **pedestrian**',
+    attachment_type: 'image',
+    attachment: 'http://i.imgur.com/XOJbalC.jpg',
+    objects_to_annotate: ['car', 'pedestrian'],
+    with_labels: true,
+    min_width: '30',
+    min_height: '30',
+    layers: {polygons: params['response']['annotations']}
+  })
+
+  # do something with the task
+end
 ```
 
 “Layers” can be used to specify existing (read-only) boxes, lines, polygons, and/or cuboids to be pre-drawn on an image.

--- a/source/includes/_imageannotation.mdown
+++ b/source/includes/_imageannotation.mdown
@@ -2,21 +2,23 @@
 > All of these input formats have the same formatting as our responses, so passing one Scale tasks' data to another Scale task is really easy.
 
 ```js
+var scaleapi = require('scaleapi');
+
+var client = scaleapi.ScaleClient('{{ApiKey}}');
+
+// This example uses express with body-parser
 app.post('/polygon_task_callback_handler', function(req, res) {
   // Validate callback auth key
   ...
 
   var polygons = req.body.response.annotations;
-
-  var scaleapi = require('scaleapi');
-
-  var client = scaleapi.ScaleClient('{{ApiKey}}')
+  var attachment = req.body.task.params.attachment;
 
   client.createAnnotationTask({
-    'callback_url': 'http://www.example.com/callback',
+    'callback_url': 'http://www.example.com/annotation_task_callback_handler',
     'instruction': 'Draw a box around each **car** and **pedestrian**',
     'attachment_type': 'image',
-    'attachment': 'http://i.imgur.com/XOJbalC.jpg',
+    'attachment': attachment,
     'objects_to_annotate': ['car', 'pedestrian'],
     'with_labels': true,
     'min_width': '30',
@@ -36,21 +38,25 @@ import scaleapi
 
 client = scaleapi.ScaleClient('{{ApiKey}}')
 
+# This example uses Flask
 @app.route('/polygon_task_callback_handler', methods=['POST'])
 def create_annotation_task():
   # Validate callback auth key
   ...
 
+  polygons = request.json['response']['annotations']
+  attachment = request.json['task']['params']['attachment']
+
   task = client.create_annotation_task(
-      callback_url='http://www.example.com/callback',
+      callback_url='http://www.example.com/annotation_task_callback_handler',
       instruction='Draw a box around each **car** and **pedestrian**',
       attachment_type='image',
-      attachment='http://i.imgur.com/XOJbalC.jpg',
+      attachment=attachment,
       objects_to_annotate=['car', 'pedestrian'],
       with_labels=True,
       min_width='30',
       min_height='30',
-      layers={'polygons': request.json['response']['annotations']}
+      layers={'polygons': polygons}
   )
 
   # do something with the task
@@ -60,21 +66,24 @@ def create_annotation_task():
 require 'scale'
 scale = Scale.new(api_key: '{{ApiKey}}')
 
-# This should be mapped to a POST route
+# This example uses Rails, and assumes you map this to a POST route
 def create_annotation_task
   # Validate callback auth key
   ...
 
+  polygons = params['response']['annotations']
+  attachment = params['task']['params']['attachment']
+
   task = scale.create_annotation_task({
-    callback_url: 'http://www.example.com/callback',
+    callback_url: 'http://www.example.com/annotation_task_callback_handler',
     instruction: 'Draw a box around each **car** and **pedestrian**',
     attachment_type: 'image',
-    attachment: 'http://i.imgur.com/XOJbalC.jpg',
+    attachment: attachment,
     objects_to_annotate: ['car', 'pedestrian'],
     with_labels: true,
     min_width: '30',
     min_height: '30',
-    layers: {polygons: params['response']['annotations']}
+    layers: {polygons: polygons}
   })
 
   # do something with the task


### PR DESCRIPTION
## Summary of changes
Adding a doc section for Annotation Layers
![image](https://user-images.githubusercontent.com/5924508/32828762-e4a69852-c9a4-11e7-96e3-c6e4a449d460.png)

Adding a mention of layers with a link for more detail in the supported tasks parameters tables (which includes categorization tasks if their attachment is of type `image`).

![image](https://user-images.githubusercontent.com/5924508/32751831-ed0136f8-c87b-11e7-89f8-6497bc5c4fab.png)
