### PR TITLE
Fix test key population

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -155,8 +155,8 @@ scale = Scale.new(api_key: '{{ApiKey}}')
 => #<Scale:0x007fcc1292fe88 @api_key="{{ApiKey}}", @callback_auth_key=nil, @default_request_params={:callback_url=>nil}, @logging=false>
 ```
 
-> <span ng-if="!user.testApiKey">You must replace <code>{{ApiKey}}</code> with your personal API key. If you <a href="https://dashboard.scaleapi.com/signup">sign up</a> or <a href="https://dashboard.scaleapi.com/login">log in</a>, your API key will be automatically filled in the docs.</span>
-> <span ng-if="user.testApiKey">Your test API key <code>{{ApiKey}}</code> is included in all the examples on this page, so you can test any example right away. Only you can see this value.</span>
+> <span ng-if="!isLoggedIn">You must replace <code>{{ApiKey}}</code> with your personal API key. If you <a href="https://dashboard.scaleapi.com/signup">sign up</a> or <a href="https://dashboard.scaleapi.com/login">log in</a>, your API key will be automatically filled in the docs.</span>
+> <span ng-if="isLoggedIn">Your test API key <code>{{ApiKey}}</code> is included in all the examples on this page, so you can test any example right away. Only you can see this value.</span>
 
 Scale uses API keys to allow access to the API. You can find your API keys on your [dashboard](https://dashboard.scaleapi.com/dashboard), which you can access by [logging in](https://dashboard.scaleapi.com/login) or [signing up](https://dashboard.scaleapi.com/signup).
 
@@ -164,11 +164,11 @@ Scale expects for the API key to be included in all API requests to the server v
 
 `-u "{{ApiKey}}:"`
 
-<aside class="notice" ng-if="!user.testApiKey">
+<aside class="notice" ng-if="!isLoggedIn">
 You must replace <code>{{ApiKey}}</code> with your personal API key. If you <a href="https://dashboard.scaleapi.com/signup">sign up</a> or <a href="https://dashboard.scaleapi.com/login">log in</a>, your API key will be automatically filled in the docs.
 </aside>
 
-<aside class="notice" ng-if="user.testApiKey">
+<aside class="notice" ng-if="isLoggedIn">
 Your test API key <code>{{ApiKey}}</code> is included in all the examples on this page, so you can test any example right away. Only you can see this value.
 </aside>
 

--- a/source/javascripts/app/_angular.js
+++ b/source/javascripts/app/_angular.js
@@ -10,33 +10,27 @@ function getJWTCookie() {
 app.controller('docsController', ["$scope", "$http", "$resource", function ($scope, $http, $resource) {
   $http.defaults.withCredentials = true;
   var jwt = getJWTCookie();
-  var getUser = { get: { method: 'GET' } };
+  var method = { get: { method: 'GET' } };
   if (jwt) {
-    getUser.get.headers = {'authorization': 'JWT ' + jwt};
+    method.get.headers = {'authorization': 'JWT ' + jwt};
   }
-  var User = $resource('https://dashboard.scaleapi.com/internal/logged_in_user', {}, getUser);
-
-  var getCustomerKeys = { get: { method: 'GET' } };
-  if (jwt) {
-    getCustomerKeys.get.headers = {'authorization': 'JWT ' + jwt};
-  }
-  var CustomerKeys = $resource('https://dashboard.scaleapi.com/internal/customer_keys', {}, getCustomerKeys);
+  var CustomerKeys = $resource('https://scaleapi.com/internal/customer_keys', {}, method);
 
   $scope.user = {};
   $scope.ApiKey = 'SCALE_API_KEY';
+  $scope.isLoggedIn = false;
 
-  User.get({}, function(user) {
-    $scope.user = user;
-
-    if ($scope.user.email) {
-      CustomerKeys.get({}, function(customerKeys) {
-        if (!customerKeys || customerKeys.test || customerKeys.test.apiKeys || customerKeys.test.apiKeys.length === 0) {
-          return;
-        }
-
-        $scope.ApiKey = customerKeys.test.apiKeys[0];
-        $scope.user.testApiKey = $scope.ApiKey
-      });
+  CustomerKeys.get({}, function(customerKeys) {
+    if (
+      !customerKeys ||
+      !customerKeys.test ||
+      !customerKeys.test.apiKeys ||
+      !customerKeys.test.apiKeys.length
+    ) {
+      return;
     }
+
+    $scope.ApiKey = customerKeys.test.apiKeys[0].key;
+    $scope.isLoggedIn = true;
   });
 }]);

--- a/source/javascripts/app/_angular.js
+++ b/source/javascripts/app/_angular.js
@@ -14,7 +14,7 @@ app.controller('docsController', ["$scope", "$http", "$resource", function ($sco
   if (jwt) {
     method.get.headers = {'authorization': 'JWT ' + jwt};
   }
-  var CustomerKeys = $resource('https://scaleapi.com/internal/customer_keys', {}, method);
+  var CustomerKeys = $resource('https://dashboard.scaleapi.com/internal/customer_keys', {}, method);
 
   $scope.user = {};
   $scope.ApiKey = 'SCALE_API_KEY';


### PR DESCRIPTION
When we stopped sending the API keys in the `logged_in_user` endpoint, we broke the integration with the docs where we show the test api key if the user is logged in. In this PR I'm fixing this!